### PR TITLE
Add OpenZiti to the list of OSS DevSec

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -215,4 +215,9 @@ h| Tools (if applicable)
 | * https://github.com/GitGuardian/ggshield[GitGuardian]
 * https://github.com/zricethezav/gitleaks[Gitleaks]
 * https://hub.steampipe.io/plugins/turbot/code[Steampipe Code Plugin]
+
+| Zero Trust Principles
+| Keep data encrypted from end-to-end and have no listening ports for malware/ransomeware to spread etc.
+| * [M-22-09](https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf)
+| * https://github.com/openziti/ziti[OpenZiti] (numerous SDKs)
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -218,6 +218,6 @@ h| Tools (if applicable)
 
 | Zero Trust Principles
 | Keep data encrypted from end-to-end and have no listening ports for malware/ransomeware to spread etc.
-| * [M-22-09](https://www.whitehouse.gov/wp-content/uploads/2022/01/M-22-09.pdf)
+| * [NIST Special Publication 800-207](https://doi.org/10.6028/NIST.SP.800-207)
 | * https://github.com/openziti/ziti[OpenZiti] (numerous SDKs)
 |===


### PR DESCRIPTION
OpenZiti allows you to embed zero trust principles directly into your code. Doing so, allows you to listen on the zero trust overlay network and not the underlay (IP/layer 3) network. There are numerous other benefits/superpowers to add zero trust connectivity into your application itself. Check out the docs over at https://openziti.github.io. Totally free and open source